### PR TITLE
Update contrib.tree.models.py

### DIFF
--- a/upy/contrib/tree/models.py
+++ b/upy/contrib/tree/models.py
@@ -175,7 +175,10 @@ class Node(G11nBase,MPTTModel):
         It returns node's slug
         """
         if self.page:
-            return self.page.slug
+            if self.page.regex:
+                return "%s/%s" % (self.page.slug, self.page.regex)
+            else:
+                return self.page.slug
         elif not self.hide_in_url:
             return self.name
         else:


### PR DESCRIPTION
Slug() property modified. Added "page.regex" in returned slug, so you can receive complete slug in treeslug property (called by urls.py). When treeslug is called, it returns complete tree slug (including regex) of all ancestors.

I have a doubt about tree_slug string returned by treeslug property. For example, if I add a node (tournament), with this regex "(?P<tournament_slug>[0-9a-zA-Z-_]+)/", and then I add another node, tournament_info, descendant of tournament, I obtain this url "^tournament/(?P<tournament_slug>[0-9a-zA-Z-_]+)//info/$" (please note the double slash)

To obtain the correct url, we can edit slug property adding a slash after slug when 'page.regex' is not defined:

```
    if self.page:
        if self.page.regex:
            return "%s/%s" % (self.page.slug, self.page.regex)
        else:
            return "%s/" % self.page.slug
    elif not self.hide_in_url:
        return self.name
    else:
        return ""
```

The second step is to remove the slash in treeslug property:

@property
    def treeslug(self):
        """
        It returns tree's slug including all ancestors
        """
        ancestors = self.get_ancestors()
        tree_slug = ""
        for node in ancestors[1:]:
            if not node.hide_in_url:
                tree_slug += "%s" % node.slug
            else:
                tree_slug += "%s" % node.slug
        return tree_slug

But i don't understand the difference between hide_in_url and not.hide_in_url

See you tomorrow ;)
